### PR TITLE
Replace ElevenLabs with OpenAI TTS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An interactive AI-powered podcast co-host that can engage in natural conversatio
 - 🎙️ **Voice Interaction**
   - Real-time voice recording
   - Speech-to-text using OpenAI's Whisper API
-  - Text-to-speech using ElevenLabs API
+  - Text-to-speech using OpenAI's TTS API
 
 - 📚 **Document Processing**
   - PDF upload and processing
@@ -29,8 +29,7 @@ An interactive AI-powered podcast co-host that can engage in natural conversatio
 - **Backend**: FastAPI (Python)
 - **Frontend**: HTML, JavaScript, Tailwind CSS
 - **AI/ML**: 
-  - OpenAI GPT-4 & Whisper
-  - ElevenLabs TTS
+  - OpenAI GPT-4, Whisper & TTS
   - LangChain
   - FAISS Vector Store
 
@@ -50,7 +49,6 @@ An interactive AI-powered podcast co-host that can engage in natural conversatio
 3. Create a `.env` file in the project root:
    ```
    OPENAI_API_KEY=your_openai_api_key
-   ELEVENLABS_API_KEY=your_elevenlabs_api_key
    ```
 
 4. Run the application:
@@ -58,7 +56,7 @@ An interactive AI-powered podcast co-host that can engage in natural conversatio
    python app/main.py
    ```
 
-5. Open your browser and navigate to `http://localhost:53269`
+5. Open your browser and navigate to `http://localhost:53997`
 
 ## Usage
 

--- a/app/main.py
+++ b/app/main.py
@@ -191,7 +191,7 @@ processing or document understanding capabilities.
     else:
         # Normal FastAPI startup - using the current module
         import uvicorn
-        uvicorn.run(app, host="0.0.0.0", port=53269, reload=False)
+        uvicorn.run(app, host="0.0.0.0", port=53997, reload=False)
 
 if __name__ == "__main__":
     run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,10 @@ fastapi
 uvicorn
 python-multipart
 jinja2
-openai
+openai>=1.0.0
 python-dotenv
 langchain
 pypdf
 faiss-cpu
-elevenlabs
 numpy
 aiofiles


### PR DESCRIPTION
## Changes Made

- Removed ElevenLabs dependencies and replaced with OpenAI TTS API
- Updated the `generate_speech` method to use OpenAI text-to-speech
- Updated documentation to reflect the changes
- Updated port number to match runtime information (53997)
- Simplified environment variables (only OpenAI API key needed now)
- Updated requirements.txt to ensure compatibility with latest OpenAI API